### PR TITLE
[Fix] DDLGeneratorTools flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,9 @@ if(ddl_cmake_enable_tests)
     add_subdirectory(test)
 endif()
 
-add_subdirectory(ddlgenerators)
+if(ddl_cmake_enable_ddl_generator_tools)
+    add_subdirectory(ddlgenerators)
+endif()
 
 if(ddl_cmake_enable_installation)
     install(TARGETS ddl ARCHIVE DESTINATION lib)


### PR DESCRIPTION
This flag could be set in the CMake configuration but it did nothing. Since building the Generator Tools requires the Clara library to be installed, this flag should definitely do something and disable this part of the project.